### PR TITLE
[Y360CMS-466] Add a date range filter to live stream API methods

### DIFF
--- a/vc.adoc
+++ b/vc.adoc
@@ -2800,6 +2800,8 @@ This operation returns brief information about Category upcoming Live Streams.
 |level[] |Array[String] |true |Workout level filter. Level names.
 |instructor[] |Array[String] |true |Instructor filter. Instructor names.
 |equipment[] |Array[String] |true |Equipment filter. Equipment names.
+|from |Integer |true |UNIX-timestamp (seconds since 1970-01-01 00:00:00 UTC) representing the earliest the live stream may begin.
+|to |Integer |true |UNIX-timestamp (seconds since 1970-01-01 00:00:00 UTC) representing the latest the live stream may end.
 | | | |
 |page |Integer |true |Page you want to retrieve, 0 indexed and defaults to 0.
 |limit |Integer |true |Size of the page you want to retrieve, defaults to 20.
@@ -2971,6 +2973,8 @@ This operation searches Live Streams. It returns brief information about live st
 |level[] |Array[String] |true |Workout level filter. Level names.
 |instructor[] |Array[String] |true |Instructor filter. Instructor names.
 |equipment[] |Array[String] |true |Equipment filter. Equipment names.
+|from |Integer |true |UNIX-timestamp (seconds since 1970-01-01 00:00:00 UTC) representing the earliest the live stream may begin.
+|to |Integer |true |UNIX-timestamp (seconds since 1970-01-01 00:00:00 UTC) representing the latest the live stream may end.
 |===
 
 [[_response_fields_16]]


### PR DESCRIPTION
JIRA issue: https://fivejars.atlassian.net/browse/Y360CMS-466

The PR proposes changes that add a date range filter (from-to) to the `Search Live stream` and `Category Live streams` methods.

The filters are UNIX-timestamps to delegate Time Zone handling to the consumer applications.